### PR TITLE
Dependency inversion principle di

### DIFF
--- a/Banksy.WebAPI/Controllers/ImportController.cs
+++ b/Banksy.WebAPI/Controllers/ImportController.cs
@@ -12,9 +12,9 @@ namespace Banksy.WebAPI.Controllers
     [ApiController]
     public class ImportController : ControllerBase
     {
-        private ImportService importService;
+        private IImportService importService;
 
-        public ImportController (ImportService importService)
+        public ImportController (IImportService importService)
         {
             this.importService = importService;
         }

--- a/Banksy.WebAPI/Services/IImportService.cs
+++ b/Banksy.WebAPI/Services/IImportService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Banksy.WebAPI.Services
 {
-    interface IImportService
+    public interface IImportService
     {
         void ImportExcel(IFormFile file);
     }

--- a/Banksy.WebAPI/Startup.cs
+++ b/Banksy.WebAPI/Startup.cs
@@ -38,7 +38,7 @@ namespace Banksy.WebAPI
             };
 
             services.AddDbContext<BanksyContext>(optionActionCreator(webApiConnectionString));
-            services.AddScoped<ImportService>();
+            services.AddScoped<IImportService, ImportService>();
             services.AddControllers();
 
             services.AddCors(options =>


### PR DESCRIPTION
Program to an interface, not an implementation. This is effectively the Dependency Inversion Principle. Doing so allows you to replace, intercept or decorate dependencies without the need to change consumers of such dependency.

https://stackoverflow.com/questions/9446502/dependency-injection-using-interfaces